### PR TITLE
packages update Feb 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+mynotes.md
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/bedrock-chat-with-pdf/Admin/admin.py
+++ b/bedrock-chat-with-pdf/Admin/admin.py
@@ -8,8 +8,8 @@ s3_client = boto3.client("s3")
 BUCKET_NAME = os.getenv("BUCKET_NAME")
 
 ## Bedrock
-from langchain_community.embeddings import BedrockEmbeddings
-
+#from langchain_community.embeddings import BedrockEmbeddings
+from langchain_aws import BedrockEmbeddings
 ## Text Splitter
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
@@ -19,8 +19,8 @@ from langchain_community.document_loaders import PyPDFLoader
 ## import FAISS
 from langchain_community.vectorstores import FAISS
 
-bedrock_client = boto3.client(service_name="bedrock-runtime")
-bedrock_embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-text-v1", client=bedrock_client)
+bedrock_client = boto3.client(service_name="bedrock-runtime", region_name="eu-west-2")
+bedrock_embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0", client=bedrock_client)
 
 def get_unique_id():
     return str(uuid.uuid4())

--- a/bedrock-chat-with-pdf/Admin/admin.py
+++ b/bedrock-chat-with-pdf/Admin/admin.py
@@ -6,6 +6,7 @@ import uuid
 ## s3_client
 s3_client = boto3.client("s3")
 BUCKET_NAME = os.getenv("BUCKET_NAME")
+REGION = os.getenv("REGION")
 
 ## Bedrock
 #from langchain_community.embeddings import BedrockEmbeddings
@@ -19,7 +20,7 @@ from langchain_community.document_loaders import PyPDFLoader
 ## import FAISS
 from langchain_community.vectorstores import FAISS
 
-bedrock_client = boto3.client(service_name="bedrock-runtime", region_name="eu-west-2")
+bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=REGION)
 bedrock_embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0", client=bedrock_client)
 
 def get_unique_id():

--- a/bedrock-chat-with-pdf/Admin/requirements.txt
+++ b/bedrock-chat-with-pdf/Admin/requirements.txt
@@ -1,5 +1,7 @@
 streamlit
 pypdf
 langchain
+langchain_community
+langchain-aws
 faiss-cpu
 boto3

--- a/bedrock-chat-with-pdf/User/requirements.txt
+++ b/bedrock-chat-with-pdf/User/requirements.txt
@@ -1,4 +1,6 @@
 streamlit
 langchain
+langchain_community
+langchain-aws
 faiss-cpu
 boto3


### PR DESCRIPTION
### package requirements
`langchain_community`  as the container would not run.
`langchain-aws` to remove deprecation message
```
/app/admin.py:23: LangChainDeprecationWarning: The class `BedrockEmbeddings` was deprecated in LangChain 0.2.11 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-aws package and should be used instead. To use it run `pip install -U :class:`~langchain-aws` and import as `from :class:`~langchain_aws import BedrockEmbeddings``.
  bedrock_embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0", client=bedrock_client)
```

### addition
added `REGION` environment variable to the boto3 client as I was getting an error
run cmd to test becomes 
```docker run -e BUCKET_NAME=AWS_BUCKET_NAME -e REGION=AWS_REGION -v ~/.aws:/root/.aws -p 8083:8083 -it chat-with-pdf-admin```

### updates
updated model `amazon.titan-embed-text-v1` to `amazon.titan-embed-text-v2:0` as there I got an invalid id error


